### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Invenio module that adds record commenting feature.
 - Paulo Cabral <paulo.cabral@cern.ch>
 - Peter Halliday <phalliday@cornell.edu>
 - Raquel Jimenez Encinar <raquel.jimenez.encinar@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Kaplun <samuele.kaplun@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Yoan Blanc <yoan.blanc@cern.ch>

--- a/invenio_comments/api.py
+++ b/invenio_comments/api.py
@@ -51,7 +51,7 @@ from invenio.legacy.dbquery import datetime_format, run_sql
 from invenio.legacy.search_engine import check_user_can_view_record, \
     guess_primary_collection_of_a_record
 from invenio.legacy.webuser import collect_user_info, get_email, get_user_info
-from invenio.modules.access.engine import acc_authorize_action
+from invenio_access.engine import acc_authorize_action
 from invenio.utils.date import convert_datestruct_to_datetext, \
     convert_datetext_to_dategui, datetext_default
 from invenio.utils.html import tidy_html
@@ -494,7 +494,7 @@ def get_collection_moderators(collection):
     """
     Return the list of comment moderators for the given collection.
     """
-    from invenio.modules.access.engine import acc_get_authorized_emails
+    from invenio_access.engine import acc_get_authorized_emails
 
     res = list(
         acc_get_authorized_emails(

--- a/invenio_comments/views.py
+++ b/invenio_comments/views.py
@@ -68,7 +68,7 @@ class CommentRights(object):
         self.id_collection = 0  # FIXME
 
     def authorize_action(self, *args, **kwargs):
-        from invenio.modules.access.engine import acc_authorize_action
+        from invenio_access.engine import acc_authorize_action
         return acc_authorize_action(*args, **kwargs)
 
     def can_perform_action(self, action=None):
@@ -188,8 +188,8 @@ def add_review(recid):
                count=comments_nb_counts)
 def comments(recid):
     """Display comments."""
-    from invenio.modules.access.local_config import VIEWRESTRCOLL
-    from invenio.modules.access.mailcookie import \
+    from invenio_access.local_config import VIEWRESTRCOLL
+    from invenio_access.mailcookie import \
         mail_cookie_create_authorize_action
     from .api import check_user_can_view_comments
     auth_code, auth_msg = check_user_can_view_comments(current_user, recid)
@@ -222,8 +222,8 @@ def comments(recid):
                count=reviews_nb_counts)
 def reviews(recid):
     """Display reviews."""
-    from invenio.modules.access.local_config import VIEWRESTRCOLL
-    from invenio.modules.access.mailcookie import \
+    from invenio_access.local_config import VIEWRESTRCOLL
+    from invenio_access.mailcookie import \
         mail_cookie_create_authorize_action
     from .api import check_user_can_view_comments
     auth_code, auth_msg = check_user_can_view_comments(current_user, recid)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.0',
     'invenio-records>=0.1.0',
 ]
@@ -49,6 +50,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
- Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
