### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -34,5 +34,5 @@ PACKAGES = [
     'invenio_records',
     'invenio_access',
     'invenio_accounts',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_comments/api.py
+++ b/invenio_comments/api.py
@@ -36,7 +36,7 @@ from datetime import datetime, timedelta
 
 from six import iteritems
 
-from invenio.base.i18n import gettext_set_language, wash_language
+from invenio_base.i18n import gettext_set_language, wash_language
 from invenio.config import CFG_COMMENTSDIR, CFG_SITE_LANG, CFG_SITE_NAME, \
     CFG_SITE_RECORD, CFG_SITE_SUPPORT_EMAIL, CFG_SITE_URL, \
     CFG_WEBALERT_ALERT_ENGINE_EMAIL, CFG_WEBCOMMENT_ADMIN_NOTIFICATION_LEVEL, \

--- a/invenio_comments/forms.py
+++ b/invenio_comments/forms.py
@@ -22,7 +22,7 @@
 from wtforms import HiddenField, SelectField, StringField, TextAreaField, \
     validators
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.utils.forms import InvenioBaseForm
 
 try:

--- a/invenio_comments/models.py
+++ b/invenio_comments/models.py
@@ -21,7 +21,7 @@
 
 from sqlalchemy import event
 
-from invenio.base.signals import record_after_update
+from invenio_base.signals import record_after_update
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 

--- a/invenio_comments/views.py
+++ b/invenio_comments/views.py
@@ -28,9 +28,9 @@ from flask_breadcrumbs import register_breadcrumb
 from flask_login import current_user, login_required
 from flask_menu import register_menu
 
-from invenio.base.decorators import templated
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.decorators import templated
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.ext.principal import permission_required
 from invenio.ext.sqlalchemy import db
 from invenio.utils.mail import email_quote_txt

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,3 +29,4 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.2',
+    'invenio-base>=0.1.0',
     'invenio-records>=0.3.2',
 ]
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 
 calculate_start_date = lazy_import(


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
