### PR TITLE
installation: fix invenio_ext imports

### DIFF
--- a/invenio_comments/api.py
+++ b/invenio_comments/api.py
@@ -47,9 +47,9 @@ from invenio.config import CFG_COMMENTSDIR, CFG_SITE_LANG, CFG_SITE_NAME, \
     CFG_WEBCOMMENT_NB_REPORTS_BEFORE_SEND_EMAIL_TO_ADMIN, \
     CFG_WEBCOMMENT_RESTRICTION_DATAFIELD, CFG_WEBCOMMENT_ROUND_DATAFIELD, \
     CFG_WEBCOMMENT_TIMELIMIT_PROCESSING_COMMENTS_IN_SECONDS
-from invenio.ext.email import send_email
-from invenio.ext.logging import register_exception
-from invenio.ext.login.legacy_user import UserInfo
+from invenio_ext.email import send_email
+from invenio_ext.logging import register_exception
+from invenio_ext.login.legacy_user import UserInfo
 from invenio.legacy.bibrecord import get_fieldvalues
 from invenio.legacy.dbquery import datetime_format, run_sql
 from invenio.legacy.search_engine import guess_primary_collection_of_a_record

--- a/invenio_comments/bundles.py
+++ b/invenio_comments/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.ext.assets import Bundle
+from invenio_ext.assets import Bundle
 
 js = Bundle(
     'js/comments/comments.js',

--- a/invenio_comments/models.py
+++ b/invenio_comments/models.py
@@ -22,8 +22,8 @@
 from sqlalchemy import event
 
 from invenio_base.signals import record_after_update
-from invenio.ext.sqlalchemy import db
-from invenio.ext.sqlalchemy.utils import session_manager
+from invenio_ext.sqlalchemy import db
+from invenio_ext.sqlalchemy.utils import session_manager
 
 from invenio_accounts.models import User
 from invenio_records.models import Record as Bibrec

--- a/invenio_comments/views.py
+++ b/invenio_comments/views.py
@@ -31,8 +31,8 @@ from flask_menu import register_menu
 from invenio_base.decorators import templated
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio.ext.principal import permission_required
-from invenio.ext.sqlalchemy import db
+from invenio_ext.principal import permission_required
+from invenio_ext.sqlalchemy import db
 from invenio.utils.mail import email_quote_txt
 from invenio_records.utils import visible_collection_tabs
 from invenio_records.views import request_record

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -30,3 +30,4 @@
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ requirements = [
     'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.2',
     'invenio-base>=0.1.0',
+    'invenio-ext>=0.1.0',
     'invenio-records>=0.3.2',
 ]
 


### PR DESCRIPTION
- FIX Adds missing invenio_ext dependency and fixes its imports.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
